### PR TITLE
PatchPilot: remediate CVEs

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(.patchpilot/output.json)",
+      "Shell(ls)",
+      "Shell(find)",
+      "Shell(rg)",
+      "Shell(grep)",
+      "Shell(cat)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(sed)",
+      "Shell(awk)"
+    ],
+    "deny": [
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(curl)",
+      "Shell(wget)",
+      "Shell(rm)",
+      "Shell(mv)",
+      "Shell(cp)",
+      "Shell(sh)",
+      "Shell(bash)"
+    ]
+  }
+}


### PR DESCRIPTION
## CVE remediation audit (moolen/logistis)

**Scanned image:** `ghcr.io/moolen/logistis:v0.1.1` (120 findings)

**Rollout mode:** Audit-only — **no repository source files were modified** (only this report). **`human_intervention_needed`: true** until Dockerfile, module, and CI updates are implemented and re-scanned.

### Outcome

**No further fixes possible in this audit rollout** — the harness did not permit changing `Dockerfile`, `go.mod`, or workflows. **Partially remediated** in the sense that the remediation path is identified; **full remediation** requires implementing the plan below and publishing a new image tag.

### Summary of actions taken

- Read `.patchpilot/input/cve-remediation.json` and cross-checked the repository.
- Confirmed the **published container** is built from the **repository root `Dockerfile`** (evidence: `.github/workflows/ci.yml` uses `docker/build-push-action` with `context: .` and default Dockerfile; `Makefile` `docker.build` uses `-f` default / same context).
- Reviewed `Dockerfile` `FROM` chain: build `golang:1.19`, run `alpine:3.14` + `apk add curl`.
- Reviewed `go.mod` (`go 1.19`) and direct/indirect dependency versions matching reported modules (e.g. `golang.org/x/net` pseudo-version, `google.golang.org/protobuf v1.28.0`, `github.com/sirupsen/logrus v1.8.1`).
- Ran local compile check: `go build -o /tmp/logistis-webhook ./cmd/webhook` and `go build -o /tmp/kubectl-blame ./cmd/kubectl-blame` (success; binaries not committed).

### Validation steps performed

- `go version` on runner: **go1.26.1** (toolchain differs from image’s **go1.19.1**; build still exercises module compile).
- `go build -o /tmp/logistis-webhook ./cmd/webhook` — **passed**.
- `go build -o /tmp/kubectl-blame ./cmd/kubectl-blame` — **passed**.
- **`govulncheck`**, **`docker build`**, and registry image re-scan **not run** (audit-only; no Dockerfile/dependency changes to validate end-to-end).

### Fixed findings

_No repository files were changed in this audit-only rollout; nothing is remediated in-tree yet._

**Grouped by where fixes would land (reference for follow-up):**
- **`Dockerfile`:** all `stdlib` scanner rows (Go **1.19.1** in image via `BASEIMAGE`); `libcrypto1.1` / `libssl1.1` / `curl` / `libcurl` (Alpine **3.14** runtime + `apk add curl`).
- **`go.mod` / `go.sum`:** `GHSA-*` rows for `golang.org/x/net`, `golang.org/x/text`, `google.golang.org/protobuf`, `github.com/golang/glog`, `github.com/sirupsen/logrus`.
- **`.github/workflows/release.yml`:** `stdlib` alignment for `kubectl-blame` release builds (**go1.19.1** tarball today).

### Safest remediation plan (for humans to implement)

1. **`Dockerfile` — build stage (`BASEIMAGE`, default `golang:1.19`)**  
   - Bump to a **current Go patch release** in the **same base image family** as today (if staying on the official `golang` image, list tags for the intended major/minor line and pick a tag that satisfies **all** `stdlib` findings; several listed fixed versions require **Go ≥ 1.25.8 / 1.26.1** for the newest CVEs — treat **1.26.1** or latest **1.26.x** / **1.25.x** patch in-family as the consolidation target after tag listing).  
   - Rebuild static binary with `CGO_ENABLED=0` as today.

2. **`Dockerfile` — runtime (`RUNIMAGE`, default `alpine:3.14`)**  
   - **Alpine 3.14 is outdated**; runtime carries **OpenSSL 1.1** (`libcrypto1.1` / `libssl1.1`) and old **curl/libcurl** matching scanner versions. Move to a **supported Alpine** (list tags; e.g. 3.20+). Newer Alpine uses **OpenSSL 3** packages (different package names), which addresses the OpenSSL 1.1 CVEs by migration, not by pinning 1.1.1t-r*.  
   - For **curl**: prefer a **pinned** `curl`/`libcurl` version from the new Alpine release that meets the listed fixed versions, or **remove curl** from the image if not needed at runtime.  
   - If the Dockerfile switches to **root for apk** and adds a **USER**, end with a **non-root** user per your policy.

3. **`go.mod` / `go.sum`**  
   - Align **`go`/`toolchain`** with the chosen Go version.  
   - Upgrade modules to at least the **minimum fixed versions** from the report, especially: **`golang.org/x/net`** (highest GHSA fix level cited is **0.38.0** / **0.36.0** among rows — use the **maximum** required), **`golang.org/x/text`** (≥ **0.3.8**), **`google.golang.org/protobuf`** (≥ **1.33.0**), **`github.com/golang/glog`** (≥ **1.2.4**), **`github.com/sirupsen/logrus`** (≥ **1.8.3**).  
   - **`k8s.io/*` v0.25.1** may need a planned upgrade path compatible with newer Go; run **`go mod tidy`** and **`govulncheck`** after bumps.

4. **`.github/workflows/release.yml`**  
   - Update **`goversion`** tarball URL from **go1.19.1** to the **same** Go version used for production builds.

5. **Validation**  
   - `go test ./...`, `go vet ./...` (or project linter), **`govulncheck ./...`**, **`docker build`** locally, then **re-scan** the pushed image.

### Remaining findings (full table)

All rows: **Status** = not fixed in repo during this audit; **Reason** = audit-only constraint.

| CVE ID | Package | File location | Status | Reason |
|--------|---------|---------------|--------|--------|
| CVE-2023-44487 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0286 | libcrypto1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0286 | libssl1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-qppj-fm5r-hxr3 | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-45288 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-4v7x-pqxf-cx7m | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24787 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24784 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24791 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24785 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0464 | libcrypto1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0464 | libssl1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24538 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24531 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0215 | libcrypto1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0215 | libssl1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24783 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29405 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-45289 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-45290 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0465 | libcrypto1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-0465 | libssl1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24540 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-34156 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-vvpx-j8f3-3w6h | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-41723 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29406 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-8r3f-844c-mc37 | google.golang.org/protobuf | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-xrjj-mj9h-534m | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-41717 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24790 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-22871 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27533 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27533 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-4304 | libcrypto1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-4304 | libssl1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-45287 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-34158 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29402 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-23914 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-23914 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-4374-p667-p6c8 | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-43552 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-43552 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-4450 | libcrypto1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-4450 | libssl1.1 | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24534 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-45336 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29404 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-69cg-p879-7622 | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-45341 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-39326 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-vvgc-356p-c3xw | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29409 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-fxg5-wq6x-vr4w | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-2wrh-6pvc-2jm9 | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-23916 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-23916 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-39318 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-39319 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24536 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27534 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27534 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24539 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-41725 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-39323 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-6wxm-mpqj-6jpf | github.com/golang/glog | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-45285 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-69ch-w2m2-3vjp | golang.org/x/text | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-34155 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29400 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27535 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27535 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-43551 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-43551 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-4f99-4q7p-p3gh | github.com/sirupsen/logrus | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-23915 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-23915 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27537 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27537 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61726 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-2880 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2026-25679 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61725 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61723 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61729 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-47906 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-68121 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-41724 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-58186 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24532 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61728 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-4673 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| GHSA-qxp5-gwg8-xv66 | golang.org/x/net | go.mod / go.sum | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-41715 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2022-2879 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-58185 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-47912 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-22866 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-24537 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-58187 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-47907 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27538 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27538 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61724 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-29403 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61731 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61727 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2026-27142 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27536 | curl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2023-27536 | libcurl | Dockerfile (RUNIMAGE alpine + apk curl) | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-58183 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61732 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-58189 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-58188 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-61730 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-4674 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2024-24789 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2026-27139 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |
| CVE-2025-22873 | stdlib | Dockerfile (BASEIMAGE), go.mod, .github/workflows/release.yml | Not fixed | Audit-only rollout; no repo changes applied |

<!-- patchpilot agent notes -->
# Notes

- **What worked well:** Repository layout clearly ties the published image `ghcr.io/moolen/logistis` to the root `Dockerfile` via `.github/workflows/ci.yml` (`docker/build-push-action`, context `.`) and `Makefile` (`docker buildx` with `DOCKERFILE := Dockerfile`). `go.mod` and dependency versions match the scanner-reported module versions for Go modules. Local `go build` for `./cmd/webhook` and `./cmd/kubectl-blame` succeeded on the runner (Go 1.26.1 toolchain), confirming the tree compiles without changes.
- **What was difficult:** This rollout was **audit-only** (modify only `.patchpilot/output.json`), so registry tag listing, image rebuild, and `govulncheck` against a remediated image could not be executed as part of a committed fix. Consolidating **120** scanner rows into a single remediation strategy requires choosing one **minimum Go toolchain** that satisfies the **maximum** fixed-version requirement across all `stdlib` CVEs (several 2025–2026 CVEs point at **Go 1.25.x / 1.26.x** lines), which implies a major jump from **Go 1.19.1** and may force **k8s.io/client-go** and related upgrades.
- **Missing tooling / context:** Docker Hub / registry tag listing for `golang` and `alpine` to pick non-guessed tags; AWS/ECR N/A here. Access to re-scan `ghcr.io/moolen/logistis` after changes. Maintainer decision on acceptable **Alpine** major version and whether to **remove runtime `curl`** or replace with a minimal static binary-only image to shrink attack surface.
<!-- patchpilot agent notes end -->

Human intervention requested by agent: true

## Agent Logs

<details>
<summary>cve-remediation stdout</summary>

```text
Here is what was done:

## Result

This rollout was **audit-only**: only **`.patchpilot/output.json`** was written (no edits to `Dockerfile`, `go.mod`, workflows, etc.). **`human_intervention_needed`** is set to **`true`**.

## Evidence used

- **Image build:** `.github/workflows/ci.yml` builds from repo root with `docker/build-push-action` (`context: .` → default **`Dockerfile`**); `Makefile` uses the same `Dockerfile` for `docker.build`.
- **Findings line up with:** `Dockerfile` (`golang:1.19`, `alpine:3.14`, `apk add curl`), `go.mod` (`go 1.19` and module versions such as `golang.org/x/net`, `protobuf`, `logrus`, …), and **`.github/workflows/release.yml`** (`go1.19.1` tarball for `kubectl-blame`).

## Output file

- **Path:** `.patchpilot/output.json`
- **Contents:** Markdown `pr_summary` with outcome, actions, validation (`go build` of both binaries to `/tmp`), **Fixed findings** (none applied; grouped by target file), **safest remediation plan**, **full 120-row table** (CVE, package, file location, status, reason), and the **Notes** block wrapped exactly in `<!-- patchpilot agent notes -->` … `<!-- patchpilot agent notes end -->`.
```
</details>