### PR TITLE
PatchPilot: remediate CVEs

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(.patchpilot/output.json)",
+      "Shell(ls)",
+      "Shell(find)",
+      "Shell(rg)",
+      "Shell(grep)",
+      "Shell(cat)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(sed)",
+      "Shell(awk)"
+    ],
+    "deny": [
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(curl)",
+      "Shell(wget)",
+      "Shell(rm)",
+      "Shell(mv)",
+      "Shell(cp)",
+      "Shell(sh)",
+      "Shell(bash)"
+    ]
+  }
+}


### PR DESCRIPTION
## Scope

This audit reviewed **moolen/logistis** for CVEs reported against published image **`ghcr.io/moolen/logistis:v0.1.1`** (120 scanner rows, **103** unique vulnerability IDs). The rollout was **audit-only**; **no** `Dockerfile`, `go.mod`, workflow, or other repository files were changed.

## Image build evidence

- **Container image**: `.github/workflows/ci.yml` builds and pushes `ghcr.io/moolen/logistis` using **`docker/build-push-action`** with **`context: .`** — the relevant **`Dockerfile`** is at the repository root.
- **Release**: `.github/workflows/release.yml` **re-tags** `ghcr.io/moolen/logistis:main` to the release tag and signs it; it also builds **`kubectl-blame`** with a **pinned Go 1.19.1** tarball (`goversion`), which should stay aligned with the **`go`** directive and **`BASEIMAGE`** when remediating.

Current **`Dockerfile`** uses **`BASEIMAGE=golang:1.19`** and **`RUNIMAGE=alpine:3.14`**, with **`apk add curl`** on the runtime stage. **`go.mod`** declares **`go 1.19`** and pulls outdated indirect modules (e.g. **`golang.org/x/net`** pseudo-version from 2022, **`google.golang.org/protobuf`** v1.28.0). These match the scanner’s **`go1.19.1`**, **Alpine 3.14-era curl/OpenSSL 1.1.1**, and module versions.

## Safest remediation plan (for a follow-up non-audit change)

1. **Go toolchain (stdlib)**: Bump the **builder** `BASEIMAGE` to a **supported** `golang` tag (stay on the official `golang` image family). To satisfy the **highest** fixed-version bars in this report (e.g. **CVE-2026-25679**, **CVE-2026-27139**, **CVE-2026-27142** → **1.25.8** / **1.26.1**), choose a **current patch** in the **1.26.x** line (or **1.25.8+** if staying on 1.25). **List tags from the registry** and pick an explicit tag — do not guess tag names. Align **`go`** in **`go.mod`**, **`release.yml`** `goversion`, and any CI lint tooling (e.g. **golangci-lint** major compatible with that Go release).

2. **Alpine runtime (OpenSSL, curl)**: Bump **`RUNIMAGE`** to a **current Alpine 3.x** (same distro family) so **`apk add curl`** resolves to **OpenSSL 3.x** and a **modern curl** (eliminates **1.1.1q** and **7.79.1-r3**-class issues). Pin **`curl`** (and transitively **libcurl**/SSL) to **specific** Alpine package versions that close the listed CVEs once you know the target Alpine release.

3. **Go modules**: After raising Go, run **`go get`** / **`go mod tidy`** to raise at least: **`golang.org/x/net`** (multiple GHSAs; highest cited floor **0.38.0** for **GHSA-vvgc-356p-c3xw**), **`google.golang.org/protobuf`** ≥ **1.33.0**, **`github.com/golang/glog`** ≥ **1.2.4**, **`github.com/sirupsen/logrus`** ≥ **1.8.3**, **`golang.org/x/text`** ≥ **0.3.8** — then **`go mod vendor`** only if the repo vendors. Run **`govulncheck ./...`** and **`go test`** / **`go build ./...`** as validation.

4. **Rebuild and re-scan**: Push a new image tag and confirm the container scanner clears findings.

## Fixed findings

*(none — audit-only; repository files were not modified.)*

## Unfixed findings (full table)

| CVE ID | Package(s) | File location | Status | Reason |
| --- | --- | --- | --- | --- |
| CVE-2022-2879 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-2880 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-41715 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-41717 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-41723 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-41724 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-41725 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-4304 | libcrypto1.1, libssl1.1 | `Dockerfile` (`RUNIMAGE` Alpine runtime; OpenSSL from base image) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-43551 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-43552 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2022-4450 | libcrypto1.1, libssl1.1 | `Dockerfile` (`RUNIMAGE` Alpine runtime; OpenSSL from base image) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-0215 | libcrypto1.1, libssl1.1 | `Dockerfile` (`RUNIMAGE` Alpine runtime; OpenSSL from base image) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-0286 | libcrypto1.1, libssl1.1 | `Dockerfile` (`RUNIMAGE` Alpine runtime; OpenSSL from base image) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-0464 | libcrypto1.1, libssl1.1 | `Dockerfile` (`RUNIMAGE` Alpine runtime; OpenSSL from base image) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-0465 | libcrypto1.1, libssl1.1 | `Dockerfile` (`RUNIMAGE` Alpine runtime; OpenSSL from base image) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-23914 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-23915 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-23916 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24531 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24532 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24534 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24536 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24537 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24538 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24539 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-24540 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-27533 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-27534 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-27535 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-27536 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-27537 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-27538 | curl, libcurl | `Dockerfile` (`apk add curl` on run stage) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29400 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29402 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29403 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29404 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29405 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29406 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-29409 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-39318 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-39319 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-39323 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-39326 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-44487 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-45285 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-45287 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-45288 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-45289 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2023-45290 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24783 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24784 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24785 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24787 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24789 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24790 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-24791 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-34155 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-34156 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-34158 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-45336 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2024-45341 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-22866 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-22871 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-22873 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-4673 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-4674 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-47906 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-47907 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-47912 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-58183 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-58185 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-58186 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-58187 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-58188 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-58189 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61723 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61724 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61725 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61726 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61727 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61728 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61729 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61730 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61731 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-61732 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2025-68121 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2026-25679 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2026-27139 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| CVE-2026-27142 | stdlib | `Dockerfile` (`BASEIMAGE` / build stage), `.github/workflows/release.yml` (`goversion` for kubectl-blame) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-2wrh-6pvc-2jm9 | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-4374-p667-p6c8 | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-4f99-4q7p-p3gh | github.com/sirupsen/logrus | `go.mod` / `go.sum` (module `github.com/sirupsen/logrus`, direct) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-4v7x-pqxf-cx7m | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-69cg-p879-7622 | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-69ch-w2m2-3vjp | golang.org/x/text | `go.mod` / `go.sum` (module `golang.org/x/text`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-6wxm-mpqj-6jpf | github.com/golang/glog | `go.mod` / `go.sum` (module `github.com/golang/glog`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-8r3f-844c-mc37 | google.golang.org/protobuf | `go.mod` / `go.sum` (module `google.golang.org/protobuf`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-fxg5-wq6x-vr4w | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-qppj-fm5r-hxr3 | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-qxp5-gwg8-xv66 | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-vvgc-356p-c3xw | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-vvpx-j8f3-3w6h | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |
| GHSA-xrjj-mj9h-534m | golang.org/x/net | `go.mod` / `go.sum` (module `golang.org/x/net`, indirect) | Not remediated | Audit-only rollout: repository modifications were not permitted. |

## Actions taken

- Read **`.patchpilot/input/cve-remediation.json`** and inspected **`Dockerfile`**, **`go.mod`**, **`.github/workflows/ci.yml`**, and **`.github/workflows/release.yml`**.
- Confirmed the **published image** is built from the **root `Dockerfile`** via **CI**.
- Did **not** modify any repository files (per audit-only constraint); did **not** run **`go build`**, **`govulncheck`**, or **Docker** builds (no remediation applied).

## Outcome

**No further fixes possible in this run.** Reason: operational constraint **audit-only** — only **`.patchpilot/output.json`** may be written; **human intervention** is required to apply **`Dockerfile` / `go.mod` / workflow** updates, **list registry tags**, rebuild, and re-scan.

## Validation steps performed

- Repository file inspection (paths above) and structured-input review (**120** findings, **103** unique IDs).
- No compilation, vulnerability scan, or image rebuild (not applicable while changes are disallowed).

<!-- patchpilot agent notes -->
# Notes

- **What worked well**: CI workflow clearly references **`ghcr.io/moolen/logistis`** and root **`Dockerfile`**; **`go.mod`** and **`Dockerfile`** ARGS make root causes obvious (Go 1.19 + Alpine 3.14 + old modules).
- **What was difficult**: Large overlapping **stdlib** finding set; choosing a **single** Go/Alpine combination that satisfies **all** cited fixed-version floors requires **registry tag listing** and **govulncheck**, which were out of scope for this audit-only pass.
- **Missing tooling / context**: Ability to **modify** the repo, **pull/tag list** from Docker Hub / GHCR, and run **`govulncheck`** / **`docker build`** would allow a definitive minimal version pin.

<!-- patchpilot agent notes end -->

Human intervention requested by agent: true

## Agent Logs

<details>
<summary>cve-remediation stdout</summary>

```text
Audit-only work is done. Summary of what was produced:

## Result

**`.patchpilot/output.json`** is written with:

- **`human_intervention_needed`: `true`** (audit-only; no repo edits allowed)
- **`pr_summary`** markdown including:
  - **Scope** — 120 scanner rows, **103** unique IDs; no `Dockerfile` / `go.mod` / workflow changes
  - **Evidence** — `ghcr.io/moolen/logistis` is built from the repo root **`Dockerfile`** via **`.github/workflows/ci.yml`** (`docker/build-push-action`, context `.`). **`.github/workflows/release.yml`** retags `:main` and pins **Go 1.19.1** for `kubectl-blame`
  - **Remediation plan** — Raise **`BASEIMAGE`** / **`go` directive** / **`release.yml` `goversion`** (registry-listed tags; stdlib floors up through **1.26.1**-class IDs), modern **`RUNIMAGE`** Alpine + pinned **`curl`**, then **`go.mod`** bumps (`golang.org/x/net`, protobuf, glog, logrus, `x/text`), **`govulncheck`**, rebuild
  - **Fixed findings** — *(none)*
  - **Unfixed findings** — Markdown table of all **103** unique IDs with package sets, file locations, status, reason
  - **Actions / outcome / validation** — As required
  - **Notes** — Inside `<!-- patchpilot agent notes -->` … `<!-- patchpilot agent notes end -->`

Repository state reviewed: **`Dockerfile`** uses `golang:1.19` and `alpine:3.14` with `apk add curl`; **`go.mod`** is **go 1.19** with stale indirect deps matching the report.
```
</details>