### PR TITLE
PatchPilot: remediate CVEs

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,28 @@
+{
+  "permissions": {
+    "allow": [
+      "Read(**)",
+      "Write(.patchpilot/output.json)",
+      "Shell(ls)",
+      "Shell(find)",
+      "Shell(rg)",
+      "Shell(grep)",
+      "Shell(cat)",
+      "Shell(head)",
+      "Shell(tail)",
+      "Shell(sed)",
+      "Shell(awk)"
+    ],
+    "deny": [
+      "Shell(git)",
+      "Shell(gh)",
+      "Shell(curl)",
+      "Shell(wget)",
+      "Shell(rm)",
+      "Shell(mv)",
+      "Shell(cp)",
+      "Shell(sh)",
+      "Shell(bash)"
+    ]
+  }
+}


### PR DESCRIPTION
## CVE remediation audit (no code changes)

This rollout was **audit-only**: the harness did not apply patches to the repository. The sections below describe the **safest remediation plan** a follow-up change should implement, and document all scanner findings as **not fixed** in this run.

### Image and build evidence

- **Scanned image:** `ghcr.io/moolen/logistis:v0.1.1`
- **Relevant container build:** CI builds and pushes from the repo root `Dockerfile` via `.github/workflows/ci.yml` (`docker/build-push-action`, context `.`). The Makefile `docker.build` target also uses that Dockerfile.
- **Release workflow:** `.github/workflows/release.yml` retags `ghcr.io/moolen/logistis:main` to the release tag (it does not rebuild the image from Dockerfile for the tag push job); the **published image contents** still originate from the Dockerfile/CI build path above.
- **Current `Dockerfile`:** build stage defaults to `golang:1.19`; run stage defaults to `alpine:3.14` with `apk add curl`. The scanned image matches **Go 1.19.1** (stdlib) and **Alpine-era** curl/OpenSSL versions from that era.

### Safest remediation plan (recommended for a non-audit follow-up)

1. **Go toolchain (stdlib):** Bump the Docker build `BASEIMAGE` to a **current patch** of Go in the same family (e.g. stay on official `golang` images). Choose a version that satisfies the **highest** fixed-version requirement across reported stdlib CVEs/GHSAs (several 2025–2026 advisories call for **1.26.1** or **1.25.8** depending on ID; **1.26.1** covers the 1.26.x-line fixes listed). Update `go` / `toolchain` in `go.mod` to match, run `go mod tidy`, and adjust `.github/workflows/release.yml` `goversion` URL so released `kubectl-blame` binaries use the same Go.
2. **Alpine runtime:** Bump `RUNIMAGE` from `alpine:3.14` to a **supported** Alpine (e.g. 3.19+). **List tags from the registry** and pick a concrete tag that ships patched `curl`/OpenSSL (do not guess tags). After bump, re-scan; if `apk add curl` still pulls vulnerable versions, pin `curl`/`libcurl` (and transitive libs) to **specific** fixed versions per Alpine security advisories.
3. **Go modules:** After the Go bump, upgrade direct/indirect deps with minimal jumps: `golang.org/x/net` to at least **0.38.0** (per GHSA-vvgc-356p-c3xw among others), `google.golang.org/protobuf` ≥ **1.33.0**, `github.com/golang/glog` ≥ **1.2.4**, `github.com/sirupsen/logrus` ≥ **1.8.3**, `golang.org/x/text` ≥ **0.3.8** (or newer compatible with k8s deps). Re-run `go mod tidy` and resolve any API/compat issues from `k8s.io/*` upgrades if required.
4. **Validation:** `go build ./...`, `go test ./...`, `govulncheck ./...`, and a fresh image scan on the rebuilt tag.

### Fixed findings

_None._ This audit did not modify repository sources.

### Findings not remediated in this audit (full table)

| CVE / Advisory | Package | File location | Status | Reason |
|---|---|---|---|---|
| CVE-2022-43551 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-43552 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-23914 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-23915 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-23916 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27533 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27534 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27535 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27536 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27537 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27538 | curl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| GHSA-6wxm-mpqj-6jpf | github.com/golang/glog | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-4f99-4q7p-p3gh | github.com/sirupsen/logrus | `go.mod` (direct) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-2wrh-6pvc-2jm9 | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-4374-p667-p6c8 | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-4v7x-pqxf-cx7m | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-69cg-p879-7622 | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-fxg5-wq6x-vr4w | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-qppj-fm5r-hxr3 | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-qxp5-gwg8-xv66 | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-vvgc-356p-c3xw | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-vvpx-j8f3-3w6h | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-xrjj-mj9h-534m | golang.org/x/net | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-69ch-w2m2-3vjp | golang.org/x/text | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| GHSA-8r3f-844c-mc37 | google.golang.org/protobuf | `go.mod` / `go.sum` (indirect) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: bump module in `go mod` / indirect upgrades after Go bump. |
| CVE-2022-4304 | libcrypto1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-4450 | libcrypto1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0215 | libcrypto1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0286 | libcrypto1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0464 | libcrypto1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0465 | libcrypto1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-43551 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-43552 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-23914 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-23915 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-23916 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27533 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27534 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27535 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27536 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27537 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-27538 | libcurl | `Dockerfile` (run: `apk add curl` on Alpine) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-4304 | libssl1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-4450 | libssl1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0215 | libssl1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0286 | libssl1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0464 | libssl1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2023-0465 | libssl1.1 | `Dockerfile` (run: `RUNIMAGE` / Alpine runtime OpenSSL) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: newer Alpine/runtime or pinned OS packages with fixed versions. |
| CVE-2022-2879 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2022-2880 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2022-41715 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2022-41717 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2022-41723 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2022-41724 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2022-41725 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24531 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24532 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24534 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24536 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24537 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24538 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24539 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-24540 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29400 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29402 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29403 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29404 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29405 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29406 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-29409 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-39318 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-39319 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-39323 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-39326 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-44487 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-45285 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-45287 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-45288 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-45289 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2023-45290 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24783 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24784 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24785 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24787 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24789 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24790 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-24791 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-34155 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-34156 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-34158 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-45336 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2024-45341 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-22866 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-22871 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-22873 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-4673 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-4674 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-47906 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-47907 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-47912 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-58183 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-58185 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-58186 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-58187 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-58188 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-58189 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61723 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61724 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61725 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61726 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61727 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61728 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61729 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61730 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61731 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-61732 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2025-68121 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2026-25679 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2026-27139 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |
| CVE-2026-27142 | stdlib | `Dockerfile` (build: `BASEIMAGE`), `go.mod` (`go` directive), `.github/workflows/release.yml` (`goversion`) | Not fixed | Audit-only rollout; no Dockerfile/go.mod/CI changes applied. Remediation: upgrade Go in Docker build + `go.mod` + release `goversion` to a patched stdlib. |

### Actions taken in this rollout

- Read `.patchpilot/input/cve-remediation.json` and reviewed `Dockerfile`, `go.mod`, `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `Makefile`.
- Confirmed the published image is produced from the root `Dockerfile` via CI (not vendored copies).
- **Did not** modify `Dockerfile`, dependencies, or workflows (audit-only).
- Local build check: `go build -o /tmp/logistis-test ./cmd/webhook` succeeded on the workspace host (Go **1.26.1**); this validates source compiles but does **not** reflect the vulnerable container toolchain in the scanned image.

### Outcome

**No further fixes possible in this audit-only execution** — repository files were intentionally unchanged. **Full remediation** requires an implementation pass: bump base images from registry-listed tags, pin OS packages if needed, upgrade Go and modules, then re-scan `ghcr.io/moolen/logistis:<new-tag>`.

### Validation steps performed

- Repository file review (build definitions and `go.mod`).
- `go build -o /tmp/logistis-test ./cmd/webhook` (host Go 1.26.1).
- No `govulncheck` / image rebuild / registry tag listing (not requested for audit-only; human follow-up should run these after patches).

<!-- patchpilot agent notes -->
# Notes

- **What worked well:** CI and Makefile clearly point at a single root `Dockerfile` for `ghcr.io/moolen/logistis`, so the blast radius for image CVEs is well defined.
- **What was difficult:** 120 findings collapse to a few root causes (old Go stdlib, old Alpine packages, stale indirect modules), but advisory fixed-version matrices are large; choosing one Go/Alpine tag requires registry tag listing and a full `govulncheck`/scan pass after changes.
- **Missing tooling/context:** Access to re-scan the rebuilt image, `docker manifest` / registry tag lists for `golang` and `alpine`, and policy on acceptable major jumps for `k8s.io/*` deps would make an implementation rollout safer and faster.
<!-- patchpilot agent notes end -->

Human intervention requested by agent: true

## Agent Logs

<details>
<summary>cve-remediation stdout</summary>

```text
## Audit complete

Work was limited to **`.patchpilot/output.json`** (audit-only; no `Dockerfile`, `go.mod`, or workflow edits).

### Evidence used

- **Image:** `ghcr.io/moolen/logistis:v0.1.1`
- **Build:** `.github/workflows/ci.yml` builds from the repo root with `docker/build-push-action` (context `.`) → root **`Dockerfile`**. `Makefile` `docker.build` uses the same file.
- **Current stack:** `Dockerfile` uses `golang:1.19` (build) and `alpine:3.14` + `apk add curl` (run); `go.mod` is `go 1.19`; **release.yml** pins **`go1.19.1`** for `kubectl-blame` binaries.

### Output file

- **Path:** `.patchpilot/output.json`
- **`human_intervention_needed`:** `true` (per audit instructions)
- **`pr_summary`:** Markdown with:
  - Safest remediation plan (Go/Alpine bumps from registry-listed tags, module bumps, validation)
  - **Fixed findings:** none (audit-only)
  - **Full table** of all **120** findings (CVE/Advisory, Package, File location, Status, Reason)
  - Actions taken, outcome, validation steps
  - **Notes** inside `<!-- patchpilot agent notes -->` … `<!-- patchpilot agent notes end -->`

Validation noted in the summary: `go build -o /tmp/logistis-test ./cmd/webhook` on host Go 1.26.1 (source compiles; does not change the scanned image’s Go 1.19.1).
```
</details>